### PR TITLE
Fix bug with emojis' encoding

### DIFF
--- a/viberbot/api/api.py
+++ b/viberbot/api/api.py
@@ -49,6 +49,7 @@ class Api(object):
 
 	def parse_request(self, request_data):
 		self._logger.debug("parsing request")
+		request_data = request_data.decode('unicode_escape').encode('utf_16_be', 'surrogatepass')
 		request_dict = json.loads(request_data)
 		request = create_request(request_dict)
 		self._logger.debug(u"parsed request={0}".format(request))


### PR DESCRIPTION
Hello. 
I've found a bug, when user fill profile name with emojis, `json.loads` can't parse it or something like that. Here's my suggestion how to fix that bug. 
![u7vdn1hm1nc](https://user-images.githubusercontent.com/4006269/35870157-fe514bb2-0b71-11e8-9476-ca4a3aa53e7b.jpg)
Thank you.