### PR TITLE
Provide an ability to define client version

### DIFF
--- a/viberbot/api/bot_configuration.py
+++ b/viberbot/api/bot_configuration.py
@@ -1,8 +1,9 @@
 class BotConfiguration(object):
-	def __init__(self, auth_token, name, avatar):
+	def __init__(self, auth_token, name, avatar, min_api_version=1):
 		self._auth_token = auth_token
 		self._name = name
 		self._avatar = avatar
+		self._min_api_version=min_api_version
 
 	@property
 	def name(self):
@@ -15,3 +16,7 @@ class BotConfiguration(object):
 	@property
 	def auth_token(self):
 		return self._auth_token
+
+	@property
+	def min_api_version(self):
+		return self._min_api_version

--- a/viberbot/api/message_sender.py
+++ b/viberbot/api/message_sender.py
@@ -64,7 +64,8 @@ class MessageSender(object):
 				'name': sender_name,
 				'avatar': sender_avatar
 			},
-			"chat_id": chat_id
+			"chat_id": chat_id,
+			"min_api_version": self._bot_configuration.min_api_version
 		})
 
 		return self._remove_empty_fields(payload)


### PR DESCRIPTION
If you want to use rich messages you have to pass min_api_version:2, but library doesn't provide such ability to pass any api version.