### PR TITLE
Fixed typo `meesage_token` (`e` -> `s`) in ViberFailedRequest and ViberSeenRequest

### DIFF
--- a/viberbot/api/viber_requests/viber_failed_request.py
+++ b/viberbot/api/viber_requests/viber_failed_request.py
@@ -1,3 +1,4 @@
+import warnings
 from future.utils import python_2_unicode_compatible
 from viberbot.api.event_type import EventType
 from viberbot.api.viber_requests.viber_request import ViberRequest
@@ -19,6 +20,11 @@ class ViberFailedRequest(ViberRequest):
 
 	@property
 	def meesage_token(self):
+		warnings.warn('Property `meesage_token` had typo and now is deprecated, please use `message_token` instead')
+		return self._message_token
+
+	@property
+	def message_token(self):
 		return self._message_token
 
 	@property

--- a/viberbot/api/viber_requests/viber_seen_request.py
+++ b/viberbot/api/viber_requests/viber_seen_request.py
@@ -1,3 +1,4 @@
+import warnings
 from future.utils import python_2_unicode_compatible
 from ..event_type import EventType
 from viberbot.api.viber_requests.viber_request import ViberRequest
@@ -17,6 +18,11 @@ class ViberSeenRequest(ViberRequest):
 
 	@property
 	def meesage_token(self):
+		warnings.warn('Property `meesage_token` had typo and now is deprecated, please use `message_token` instead')
+		return self._message_token
+
+	@property
+	def message_token(self):
 		return self._message_token
 
 	@property


### PR DESCRIPTION
Hi, I found a typo in `ViberFailedRequest` and `ViberSeenRequest` that was really annoying for me
(as you need to remember which property to call for which `event_type`).

So created a PR that solves this problem.
Compatibility with existing projects is preserved.